### PR TITLE
Create component for screen filter effect

### DIFF
--- a/BC Game Jam Starter/Assets/Scripts.meta
+++ b/BC Game Jam Starter/Assets/Scripts.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 6dd5577ccc1e10d4780e873737bab49c
+folderAsset: yes
+timeCreated: 1518239962
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BC Game Jam Starter/Assets/Scripts/PixelScreenDistortion.cs
+++ b/BC Game Jam Starter/Assets/Scripts/PixelScreenDistortion.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PixelScreenDistortion : MonoBehaviour {
+
+    /// <summary>
+    /// The visible area to show.
+    /// </summary>
+    public float VisibleAreaRadius = 200;
+
+    /// <summary>
+    /// How big should the "distorted" pixels be?
+    /// </summary>
+    public float PixelGranularity = 16;
+
+    /// <summary>
+    /// The material used to distort the screen.
+    /// </summary>
+    private UnityEngine.Material pixelMaterial;
+
+    private void Awake()
+    {
+        this.pixelMaterial = new Material(Shader.Find("Hidden/PixelDistortion"));
+    }
+
+    /// <summary>
+    /// Called each time we render to the screen.
+    /// </summary>
+    /// <param name="inputTexture">The source texture to use when applying the distortion.</param>
+    /// <param name="outputTexture">The texture we want to write to with our finished product.</param>
+	public void OnRenderImage(RenderTexture inputTexture, RenderTexture outputTexture)
+    {
+        this.pixelMaterial.SetFloat("_pixelGranularity", this.PixelGranularity);
+        this.pixelMaterial.SetFloat("_radius", this.VisibleAreaRadius);
+        this.pixelMaterial.SetFloat("_cursorX", 100 + 200 * Mathf.Sin(UnityEngine.Time.time));
+        this.pixelMaterial.SetFloat("_cursorY", 200.0f);
+        this.pixelMaterial.SetFloat("_textureWidth", inputTexture.width);
+        this.pixelMaterial.SetFloat("_textureHeight", inputTexture.height);
+
+        Graphics.Blit(inputTexture, outputTexture, this.pixelMaterial);
+    }
+}

--- a/BC Game Jam Starter/Assets/Scripts/PixelScreenDistortion.cs
+++ b/BC Game Jam Starter/Assets/Scripts/PixelScreenDistortion.cs
@@ -7,7 +7,12 @@ public class PixelScreenDistortion : MonoBehaviour {
     /// <summary>
     /// The visible area to show.
     /// </summary>
-    public float VisibleAreaRadius = 200;
+    public float VisibleAreaRadius = 50;
+
+    /// <summary>
+    /// The visible area to show.
+    /// </summary>
+    public float IntermediateRatio = 0.1f;
 
     /// <summary>
     /// How big should the "distorted" pixels be?
@@ -31,10 +36,13 @@ public class PixelScreenDistortion : MonoBehaviour {
     /// <param name="outputTexture">The texture we want to write to with our finished product.</param>
 	public void OnRenderImage(RenderTexture inputTexture, RenderTexture outputTexture)
     {
+        this.VisibleAreaRadius = Mathf.Max(this.VisibleAreaRadius, 0);
+
         this.pixelMaterial.SetFloat("_pixelGranularity", this.PixelGranularity);
         this.pixelMaterial.SetFloat("_radius", this.VisibleAreaRadius);
-        this.pixelMaterial.SetFloat("_cursorX", 100 + 200 * Mathf.Sin(UnityEngine.Time.time));
-        this.pixelMaterial.SetFloat("_cursorY", 200.0f);
+        this.pixelMaterial.SetFloat("_intermediateRatio", this.IntermediateRatio);
+        this.pixelMaterial.SetFloat("_cursorX", UnityEngine.Input.mousePosition.x);
+        this.pixelMaterial.SetFloat("_cursorY", inputTexture.height - UnityEngine.Input.mousePosition.y);
         this.pixelMaterial.SetFloat("_textureWidth", inputTexture.width);
         this.pixelMaterial.SetFloat("_textureHeight", inputTexture.height);
 

--- a/BC Game Jam Starter/Assets/Scripts/PixelScreenDistortion.cs.meta
+++ b/BC Game Jam Starter/Assets/Scripts/PixelScreenDistortion.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 07e2d59b169d162468a4d902a1a3d5b7
+timeCreated: 1518240023
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BC Game Jam Starter/Assets/Shaders.meta
+++ b/BC Game Jam Starter/Assets/Shaders.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 670c7f0f8c9a9ec45b7be7e0fe51c4af
+folderAsset: yes
+timeCreated: 1518240463
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BC Game Jam Starter/Assets/Shaders/PixelDistortion.shader
+++ b/BC Game Jam Starter/Assets/Shaders/PixelDistortion.shader
@@ -1,0 +1,60 @@
+﻿Shader "Hidden/PixelDistortion"
+{
+	Properties
+	{
+		_MainTex ("Texture", 2D) = "white" {}
+	}
+		SubShader
+	{
+		// No culling or depth
+		Cull Off ZWrite Off ZTest Always
+
+		Pass
+		{
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+
+			#include "UnityCG.cginc"
+
+			uniform float _pixelGranularity;
+			uniform float _radius;
+			uniform float _cursorX;
+			uniform float _cursorY;
+			uniform float _textureWidth;
+			uniform float _textureHeight;
+
+			struct appdata
+			{
+				float4 vertex : POSITION;
+				float2 uv : TEXCOORD0;
+			};
+
+			struct v2f
+			{
+				float2 uv : TEXCOORD0;
+				float4 vertex : SV_POSITION;
+			};
+
+			v2f vert (appdata v)
+			{
+				v2f o;
+				o.vertex = UnityObjectToClipPos(v.vertex);
+				o.uv = v.uv;
+				return o;
+			}
+			
+			sampler2D _MainTex;
+
+			fixed4 frag (v2f i) : SV_Target
+			{
+				fixed4 col = tex2D(_MainTex, i.uv);
+				if (sqrt(pow((i.vertex.xy.x - _cursorX), 2.0) + pow((i.vertex.xy.y - _cursorY),2.0)) > _radius) {
+					col = tex2D(_MainTex, float2(_pixelGranularity * floor(i.vertex.xy.x / _pixelGranularity) / _textureWidth, (1 - (_pixelGranularity * floor(i.vertex.xy.y / _pixelGranularity)) / _textureHeight)));
+				}
+				return col;
+			}
+			ENDCG
+		}
+	}
+}

--- a/BC Game Jam Starter/Assets/Shaders/PixelDistortion.shader
+++ b/BC Game Jam Starter/Assets/Shaders/PixelDistortion.shader
@@ -19,6 +19,7 @@
 
 			uniform float _pixelGranularity;
 			uniform float _radius;
+			uniform float _intermediateRatio;
 			uniform float _cursorX;
 			uniform float _cursorY;
 			uniform float _textureWidth;
@@ -49,8 +50,13 @@
 			fixed4 frag (v2f i) : SV_Target
 			{
 				fixed4 col = tex2D(_MainTex, i.uv);
-				if (sqrt(pow((i.vertex.xy.x - _cursorX), 2.0) + pow((i.vertex.xy.y - _cursorY),2.0)) > _radius) {
+				float distFromCursor = sqrt(pow((i.vertex.xy.x - _cursorX), 2.0) + pow((i.vertex.xy.y - _cursorY), 2.0));
+				if (distFromCursor > _radius) {
 					col = tex2D(_MainTex, float2(_pixelGranularity * floor(i.vertex.xy.x / _pixelGranularity) / _textureWidth, (1 - (_pixelGranularity * floor(i.vertex.xy.y / _pixelGranularity)) / _textureHeight)));
+				}
+				else if (distFromCursor > _radius - (_radius * _intermediateRatio)) {
+					float varyingGranularity = _pixelGranularity / 2;
+					col = tex2D(_MainTex, float2(varyingGranularity * floor(i.vertex.xy.x / varyingGranularity) / _textureWidth, (1 - (varyingGranularity * floor(i.vertex.xy.y / varyingGranularity)) / _textureHeight)));
 				}
 				return col;
 			}

--- a/BC Game Jam Starter/Assets/Shaders/PixelDistortion.shader.meta
+++ b/BC Game Jam Starter/Assets/Shaders/PixelDistortion.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 4dc42c90d2bc2554c9d013010b544fd4
+timeCreated: 1518240481
+licenseType: Free
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR adds a new component for making a "pixel filter" over the camera view. We create this effect by using a shader over the game view. The shader "downsamples" the scene by having each pixel take the color of it's neighbour that is in the top-right corner of the square cell it happens to be in.

To use it, attach it to the same game object that has the `Camera` component and it should "just work". UI elements on the canvas will not be affected.

If it breaks complain at Daniel.